### PR TITLE
Update standard_suggestions_box.dart

### DIFF
--- a/lib/old/standard_suggestions_box.dart
+++ b/lib/old/standard_suggestions_box.dart
@@ -92,6 +92,7 @@ class StandardSuggestionsBox extends StatelessWidget {
             color: Colors.transparent,
             child: ListView.builder(
               itemCount: suggestions.length,
+              padding: EdgeInsets.zero,
               itemBuilder: (context, index) {
                 return InkWell(
                   hoverColor: hoverColor,


### PR DESCRIPTION
I reset the edge insets because there was an unnecessary space at the beginning of the suggestions list.

<img width="264" alt="image" src="https://github.com/user-attachments/assets/9e789310-77a1-4cf6-9bef-108dcdd94ce0">
